### PR TITLE
Added support for strings as keys from keyword lists

### DIFF
--- a/lib/bark.ex
+++ b/lib/bark.ex
@@ -23,7 +23,7 @@ defmodule Bark do
   defp to_log_formatted_string(keywords) do
     keywords
     |> Enum.map(fn {key, value} ->
-      "#{Atom.to_string(key)}=#{log_value(value)}"
+      "#{log_value(key)}=#{log_value(value)}"
     end)
     |> Enum.join(" ")
   end

--- a/test/log_test.exs
+++ b/test/log_test.exs
@@ -11,6 +11,18 @@ defmodule LogTest do
                tuple: {:tuple, :ok}
              ) == :ok
     end
+
+    test "can log a list of keywords as strings" do
+      assert Bark.warn(
+               __ENV__,
+               [
+                 {"speak", "woof"},
+                 {"number", 1},
+                 {"map", %{"something" => "neet"}},
+                 {"tuple", {:tuple, :ok}}
+               ]
+             ) == :ok
+    end
   end
 
   describe "warn" do
@@ -20,6 +32,18 @@ defmodule LogTest do
                number: 1,
                map: %{something: "neet"},
                tuple: {:tuple, :ok}
+             ) == :ok
+    end
+
+    test "can log a list of keywords as strings" do
+      assert Bark.warn(
+               __ENV__,
+               [
+                 {"speak", "woof"},
+                 {"number", 1},
+                 {"map", %{"something" => "neet"}},
+                 {"tuple", {:tuple, :ok}}
+               ]
              ) == :ok
     end
   end
@@ -33,6 +57,18 @@ defmodule LogTest do
                tuple: {:tuple, :ok}
              ) == :ok
     end
+
+    test "can log a list of keywords as strings" do
+      assert Bark.warn(
+               __ENV__,
+               [
+                 {"speak", "woof"},
+                 {"number", 1},
+                 {"map", %{"something" => "neet"}},
+                 {"tuple", {:tuple, :ok}}
+               ]
+             ) == :ok
+    end
   end
 
   describe "debug" do
@@ -42,6 +78,18 @@ defmodule LogTest do
                number: 1,
                map: %{something: "neet"},
                tuple: {:tuple, :ok}
+             ) == :ok
+    end
+
+    test "can log a list of keywords as strings" do
+      assert Bark.warn(
+               __ENV__,
+               [
+                 {"speak", "woof"},
+                 {"number", 1},
+                 {"map", %{"something" => "neet"}},
+                 {"tuple", {:tuple, :ok}}
+               ]
              ) == :ok
     end
   end

--- a/test/log_test.exs
+++ b/test/log_test.exs
@@ -13,7 +13,7 @@ defmodule LogTest do
     end
 
     test "can log a list of keywords as strings" do
-      assert Bark.warn(
+      assert Bark.info(
                __ENV__,
                [
                  {"speak", "woof"},
@@ -59,7 +59,7 @@ defmodule LogTest do
     end
 
     test "can log a list of keywords as strings" do
-      assert Bark.warn(
+      assert Bark.error(
                __ENV__,
                [
                  {"speak", "woof"},
@@ -82,7 +82,7 @@ defmodule LogTest do
     end
 
     test "can log a list of keywords as strings" do
-      assert Bark.warn(
+      assert Bark.debug(
                __ENV__,
                [
                  {"speak", "woof"},


### PR DESCRIPTION
## Description
`Bark.warn/2` `Bark.info/2` `Bark.error/2` `Bark.debug/2` all accept a keyword list as a the second argument. Bark assumes the keyword list keys are atoms. This update uses pattern matching to ensure the keyword list keys can be any type already supported by the `log_value` function.