### PR TITLE
ENG: Logger.warn deprecated for Logger.warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # 1.2.0
 
 - Swap out `Logger.warn` for `Logger.warning` to get rid of deprecation warnings.
+- Minimum of Elixir 1.11 required instead of 1.9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.2.0
+
+- Swap out `Logger.warn` for `Logger.warning` to get rid of deprecation warnings.

--- a/lib/bark.ex
+++ b/lib/bark.ex
@@ -3,7 +3,7 @@ defmodule Bark do
 
   # Logs a list of kv pairs
   @spec warn(any(), Keyword.t()) :: any()
-  def warn(env, opts), do: Logger.warn(parse_message(env, opts))
+  def warn(env, opts), do: Logger.warning(parse_message(env, opts))
 
   @spec info(any(), Keyword.t()) :: any()
   def info(env, opts), do: Logger.info(parse_message(env, opts))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bark.MixProject do
   def project do
     [
       app: :bark,
-      version: "1.1.2",
+      version: "1.2.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Bark.MixProject do
     [
       app: :bark,
       version: "1.2.0",
-      elixir: "~> 1.9",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       package: package(),
       deps: deps()


### PR DESCRIPTION
To help with https://github.com/smartrent/control.smartrent.com/pull/11333