### PR TITLE
Adding audit log interface

### DIFF
--- a/lib/bark.ex
+++ b/lib/bark.ex
@@ -8,6 +8,9 @@ defmodule Bark do
   @spec info(any(), Keyword.t()) :: any()
   def info(env, opts), do: Logger.info(parse_message(env, opts))
 
+  @spec audit(any(), Keyword.t()) :: any()
+  def audit(env, opts), do: Logger.notice(parse_message(env, opts))
+
   @spec error(any(), Keyword.t()) :: any()
   def error(env, opts), do: Logger.error(parse_message(env, opts))
 

--- a/test/log_test.exs
+++ b/test/log_test.exs
@@ -25,6 +25,29 @@ defmodule LogTest do
     end
   end
 
+  describe "audit" do
+    test "can log a list of keywords" do
+      assert Bark.audit(__ENV__,
+               speak: "woof",
+               number: 1,
+               map: %{something: "neet"},
+               tuple: {:tuple, :ok}
+             ) == :ok
+    end
+
+    test "can log a list of keywords as strings" do
+      assert Bark.audit(
+               __ENV__,
+               [
+                 {"speak", "woof"},
+                 {"number", 1},
+                 {"map", %{"something" => "neet"}},
+                 {"tuple", {:tuple, :ok}}
+               ]
+             ) == :ok
+    end
+  end
+
   describe "warn" do
     test "can log a list of keywords" do
       assert Bark.warn(__ENV__,


### PR DESCRIPTION
This PR is intended to start the dialog for what an interface could look like for audit level log events. 

There is no common standard for `audit` level logs, so I'm suggesting we could use the notice level here. 

The supported levels, ordered by importance, from Logger:

:emergency - when system is unusable, panics
:alert - for alerts, actions that must be taken immediately, ex. corrupted database
:critical - for critical conditions
:error - for errors
:warning - for warnings
:notice - for normal, but significant, messages
:info - for information of any kind
:debug - for debug-related messages

ref: https://hexdocs.pm/logger/1.12.3/Logger.html#module-levels


An argument could be made for sticking with the info level. 
Also, we could enforce more in the interface of this method to help conformity of audit log messages, but I don't feel like this package is the right place to do that. 
