### PR TITLE
ENG: Accurate Specs

### DIFF
--- a/lib/bark.ex
+++ b/lib/bark.ex
@@ -1,7 +1,10 @@
 defmodule Bark do
+  @moduledoc """
+  `Bark` is a wrapper around `Logger` that adds context and standard formatting to your logs.
+  """
+
   require Logger
 
-  # Logs a list of kv pairs
   @spec warn(Macro.Env.t(), Keyword.t()) :: :ok
   def warn(env, opts), do: Logger.warning(parse_message(env, opts))
 

--- a/lib/bark.ex
+++ b/lib/bark.ex
@@ -2,19 +2,19 @@ defmodule Bark do
   require Logger
 
   # Logs a list of kv pairs
-  @spec warn(any(), Keyword.t()) :: any()
+  @spec warn(Macro.Env.t(), Keyword.t()) :: :ok
   def warn(env, opts), do: Logger.warning(parse_message(env, opts))
 
-  @spec info(any(), Keyword.t()) :: any()
+  @spec info(Macro.Env.t(), Keyword.t()) :: :ok
   def info(env, opts), do: Logger.info(parse_message(env, opts))
 
-  @spec audit(any(), Keyword.t()) :: any()
+  @spec audit(Macro.Env.t(), Keyword.t()) :: :ok
   def audit(env, opts), do: Logger.notice(parse_message(env, opts))
 
-  @spec error(any(), Keyword.t()) :: any()
+  @spec error(Macro.Env.t(), Keyword.t()) :: :ok
   def error(env, opts), do: Logger.error(parse_message(env, opts))
 
-  @spec debug(any(), Keyword.t()) :: any()
+  @spec debug(Macro.Env.t(), Keyword.t()) :: :ok
   def debug(env, opts), do: Logger.debug(parse_message(env, opts))
 
   defp parse_message(env, opts) when is_list(opts) do


### PR DESCRIPTION
I noticed a common pattern showing up in some codebases:

```elixir
case something() do
  {:ok, _} -> :ok
  error -> Bark.error(__ENV__, details: error)
end
```

This seems fine at first, but in reality we are returning `:ok` in the error condition and the caller of this function (like `Oban`) will think it was a success.

I'm hoping this spec update will increase clarity and prevent subtle bugs.