### PR TITLE
Feat: Adds support for `:ansi_color`

### DIFF
--- a/lib/bark.ex
+++ b/lib/bark.ex
@@ -6,21 +6,39 @@ defmodule Bark do
   require Logger
 
   @spec warn(Macro.Env.t(), Keyword.t()) :: :ok
-  def warn(env, opts), do: Logger.warning(parse_message(env, opts))
+  def warn(env, opts), do: Logger.warning(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @spec info(Macro.Env.t(), Keyword.t()) :: :ok
-  def info(env, opts), do: Logger.info(parse_message(env, opts))
+  def info(env, opts), do: Logger.info(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @spec audit(Macro.Env.t(), Keyword.t()) :: :ok
-  def audit(env, opts), do: Logger.notice(parse_message(env, opts))
+  def audit(env, opts), do: Logger.notice(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @spec error(Macro.Env.t(), Keyword.t()) :: :ok
-  def error(env, opts), do: Logger.error(parse_message(env, opts))
+  def error(env, opts), do: Logger.error(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @spec debug(Macro.Env.t(), Keyword.t()) :: :ok
-  def debug(env, opts), do: Logger.debug(parse_message(env, opts))
+  def debug(env, opts), do: Logger.debug(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+
+  defp validate_ansi_color(color) when is_atom(color) do
+    valid_colors = [
+      :black, :red, :green, :yellow, :blue, :magenta, :cyan, :white,
+      :light_black, :light_red, :light_green, :light_yellow, :light_blue,
+      :light_magenta, :light_cyan, :light_white,
+      :black_background, :red_background, :green_background, :yellow_background,
+      :blue_background, :magenta_background, :cyan_background, :white_background,
+      :light_black_background, :light_red_background, :light_green_background,
+      :light_yellow_background, :light_blue_background, :light_magenta_background,
+      :light_cyan_background, :light_white_background
+    ]
+
+    if color in valid_colors, do: color, else: nil
+  end
+  defp validate_ansi_color(_), do: nil
 
   defp parse_message(env, opts) when is_list(opts) do
+    opts = Keyword.drop(opts, [:ansi_color])
+
     env
     |> add_caller_context(opts)
     |> to_log_formatted_string()


### PR DESCRIPTION
This PR adds support for validating and forwarding `:ansi_color` to the various logger calls.  We also remove the `ansi_color` key before logging.


<img width="682" alt="Screenshot 2025-05-02 at 12 04 40 PM" src="https://github.com/user-attachments/assets/e18d5acd-64a7-4c3c-a7d9-e6f91ddd450b" />
