### PR TITLE
ENG: Add custom formatter that sorts/highlights metadata

### DIFF
--- a/lib/bark.ex
+++ b/lib/bark.ex
@@ -6,29 +6,60 @@ defmodule Bark do
   require Logger
 
   @spec warn(Macro.Env.t(), Keyword.t()) :: :ok
-  def warn(env, opts), do: Logger.warning(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+  def warn(env, opts),
+    do:
+      Logger.warning(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @spec info(Macro.Env.t(), Keyword.t()) :: :ok
-  def info(env, opts), do: Logger.info(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+  def info(env, opts),
+    do: Logger.info(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @spec audit(Macro.Env.t(), Keyword.t()) :: :ok
-  def audit(env, opts), do: Logger.notice(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+  def audit(env, opts),
+    do:
+      Logger.notice(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @spec error(Macro.Env.t(), Keyword.t()) :: :ok
-  def error(env, opts), do: Logger.error(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+  def error(env, opts),
+    do: Logger.error(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @spec debug(Macro.Env.t(), Keyword.t()) :: :ok
-  def debug(env, opts), do: Logger.debug(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+  def debug(env, opts),
+    do: Logger.debug(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @valid_colors [
-    :black, :red, :green, :yellow, :blue, :magenta, :cyan, :white,
-    :light_black, :light_red, :light_green, :light_yellow, :light_blue,
-    :light_magenta, :light_cyan, :light_white,
-    :black_background, :red_background, :green_background, :yellow_background,
-    :blue_background, :magenta_background, :cyan_background, :white_background,
-    :light_black_background, :light_red_background, :light_green_background,
-    :light_yellow_background, :light_blue_background, :light_magenta_background,
-    :light_cyan_background, :light_white_background
+    :black,
+    :red,
+    :green,
+    :yellow,
+    :blue,
+    :magenta,
+    :cyan,
+    :white,
+    :light_black,
+    :light_red,
+    :light_green,
+    :light_yellow,
+    :light_blue,
+    :light_magenta,
+    :light_cyan,
+    :light_white,
+    :black_background,
+    :red_background,
+    :green_background,
+    :yellow_background,
+    :blue_background,
+    :magenta_background,
+    :cyan_background,
+    :white_background,
+    :light_black_background,
+    :light_red_background,
+    :light_green_background,
+    :light_yellow_background,
+    :light_blue_background,
+    :light_magenta_background,
+    :light_cyan_background,
+    :light_white_background
   ]
 
   defp validate_ansi_color(color) when color in @valid_colors, do: color

--- a/lib/sorted_metadata_formatter.ex
+++ b/lib/sorted_metadata_formatter.ex
@@ -1,0 +1,98 @@
+defmodule Bark.SortedMetadataFormatter do
+  @moduledoc """
+  Custom logger formatter that sorts metadata keys alphabetically.
+
+  https://hexdocs.pm/logger/Logger.Formatter.html
+  """
+
+  require Logger
+
+  @default_format "[$level] $message\n"
+
+  @doc """
+  ## Examples
+
+      iex> Bark.SortedMetadataFormatter.format(:info, "hello", DateTime.utc_now(), [key: "hello", c: "c", d: "d", z: "z", a: "a"])
+      ["[", "info", "] ", "a=a c=c d=d key=hello z=z hello", "\n"]
+  """
+  @spec format(atom(), IO.chardata(), Logger.Formatter.date_time_ms(), keyword()) :: IO.chardata()
+  def format(level, message, timestamp, metadata) when is_binary(message) do
+    if String.contains?(message, "key=") do
+      format_sorted_message_metadata(level, message, timestamp, metadata)
+    else
+      Logger.Formatter.format(
+        Logger.Formatter.compile(@default_format),
+        level,
+        timestamp,
+        timestamp,
+        metadata
+      )
+      |> dbg()
+    end
+  end
+
+  def format(level, message, timestamp, metadata) do
+    dbg(message)
+
+    Logger.Formatter.format(
+      Logger.Formatter.compile(@default_format),
+      level,
+      message,
+      timestamp,
+      metadata
+    )
+  end
+
+  defp format_sorted_message_metadata(level, message, timestamp, _metadata) do
+    {metadata, message} =
+      message
+      |> String.split(" ")
+      |> Enum.split_with(fn piece -> String.contains?(piece, "=") end)
+
+    metadata =
+      Enum.map(metadata, fn string_pair ->
+        # Split each pair by "=" into a key and a value
+        [key, value] = String.split(string_pair, "=", parts: 2)
+        {String.to_existing_atom(key), value}
+      end)
+
+    # Display the key first regardless of alphabetical order
+    {key, metadata} = Keyword.pop(metadata, :key)
+    {module, metadata} = Keyword.pop(metadata, :module)
+    {command, metadata} = Keyword.pop(metadata, :command)
+    {line, metadata} = Keyword.pop(metadata, :line)
+
+    first_meta =
+      [
+        key: key,
+        module: module,
+        command: command,
+        line: line
+      ]
+      |> Enum.reject(fn {_, value} -> is_nil(value) end)
+      |> Enum.map(fn
+        {:key, value} ->
+          IO.ANSI.format([:cyan, "key=#{value}"])
+
+        {key, value} ->
+          "#{key}=#{value}"
+      end)
+      |> Enum.join(" ")
+
+    sorted_metadata =
+      metadata
+      |> Enum.sort_by(fn {key, _value} -> to_string(key) end)
+      |> Enum.map(fn {key, value} ->
+        "#{key}=#{value}"
+      end)
+      |> Enum.join(" ")
+
+    Logger.Formatter.format(
+      Logger.Formatter.compile(@default_format),
+      level,
+      "#{first_meta} #{sorted_metadata} #{message}",
+      timestamp,
+      []
+    )
+  end
+end


### PR DESCRIPTION
In order to test with a repo like CMW, update your `mix.exs` to point to this branch, and then configure:

```elixir
# config/config.exs

# https://hexdocs.pm/logger/Logger.html#module-backends-and-backwards-compatibility
config :logger, :default_formatter, format: {Bark.SortedMetadataFormatter, :format}
```

Before:
<img width="2460" height="488" alt="CleanShot 2025-07-25 at 16 18 50@2x" src="https://github.com/user-attachments/assets/0e5882d5-0c9d-4bef-bb8f-d18cfa1ecf1c" />

After:
<img width="2300" height="302" alt="CleanShot 2025-07-25 at 16 14 30@2x" src="https://github.com/user-attachments/assets/277cf233-d3c5-41eb-bade-a5c2a6655c5e" />

There are still some lingering issues though trying to apply the formatting at this layer since `Bark` moves metadata fields into the actual message:
```sh
[(bark 1.2.1) lib/sorted_metadata_formatter.ex:23: Bark.SortedMetadataFormatter.format/4]
message #=> "Running ControlRoomWeb.Endpoint with cowboy 2.12.0 at 0.0.0.0:4000 (http)"

Logger - error: {removed_failing_handler,'Elixir.Phoenix.LiveReloader.WebConsoleLogger'}
[(bark 1.2.1) lib/sorted_metadata_formatter.ex:23: Bark.SortedMetadataFormatter.format/4]
message #=> "Running ControlRoomWeb.Endpoint with cowboy 2.12.0 at 0.0.0.0:4000 (http)"

FORMATTER ERROR: bad return value
[(bark 1.2.1) lib/sorted_metadata_formatter.ex:23: Bark.SortedMetadataFormatter.format/4]
message #=> "Access ControlRoomWeb.Endpoint at http://localhost:4000"

FORMATTER ERROR: bad return value
```