### PR TITLE
Add support for `require Bark`. Deprecate Bark.*/2

### DIFF
--- a/lib/bark.ex
+++ b/lib/bark.ex
@@ -5,20 +5,112 @@ defmodule Bark do
 
   require Logger
 
-  @spec warn(Macro.Env.t(), Keyword.t()) :: :ok
-  def warn(env, opts), do: Logger.warning(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+  # New style macros (recommended)
+  defmacro warn(opts \\ []) do
+    quote do
+      require Logger
+      Logger.warning(
+        Bark.parse_message(__ENV__, unquote(opts)),
+        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
+      )
+    end
+  end
 
-  @spec info(Macro.Env.t(), Keyword.t()) :: :ok
-  def info(env, opts), do: Logger.info(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+  defmacro info(opts \\ []) do
+    quote do
+      require Logger
+      Logger.info(
+        Bark.parse_message(__ENV__, unquote(opts)),
+        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
+      )
+    end
+  end
 
-  @spec audit(Macro.Env.t(), Keyword.t()) :: :ok
-  def audit(env, opts), do: Logger.notice(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+  defmacro audit(opts \\ []) do
+    quote do
+      require Logger
+      Logger.notice(
+        Bark.parse_message(__ENV__, unquote(opts)),
+        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
+      )
+    end
+  end
 
-  @spec error(Macro.Env.t(), Keyword.t()) :: :ok
-  def error(env, opts), do: Logger.error(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+  defmacro error(opts \\ []) do
+    quote do
+      require Logger
+      Logger.error(
+        Bark.parse_message(__ENV__, unquote(opts)),
+        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
+      )
+    end
+  end
 
-  @spec debug(Macro.Env.t(), Keyword.t()) :: :ok
-  def debug(env, opts), do: Logger.debug(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
+  defmacro debug(opts \\ []) do
+    quote do
+      require Logger
+      Logger.debug(
+        Bark.parse_message(__ENV__, unquote(opts)),
+        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
+      )
+    end
+  end
+
+  # Deprecated old style macros (backward compatibility)
+  @deprecated "Use Bark.warn(opts) instead of Bark.warn(__ENV__, opts)"
+  defmacro warn(env, opts) do
+    quote do
+      require Logger
+      Logger.warning(
+        Bark.parse_message(unquote(env), unquote(opts)),
+        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
+      )
+    end
+  end
+
+  @deprecated "Use Bark.info(opts) instead of Bark.info(__ENV__, opts)"
+  defmacro info(env, opts) do
+    quote do
+      require Logger
+      Logger.info(
+        Bark.parse_message(unquote(env), unquote(opts)),
+        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
+      )
+    end
+  end
+
+  @deprecated "Use Bark.audit(opts) instead of Bark.audit(__ENV__, opts)"
+  defmacro audit(env, opts) do
+    quote do
+      require Logger
+      Logger.notice(
+        Bark.parse_message(unquote(env), unquote(opts)),
+        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
+      )
+    end
+  end
+
+  @deprecated "Use Bark.error(opts) instead of Bark.error(__ENV__, opts)"
+  defmacro error(env, opts) do
+    quote do
+      require Logger
+      Logger.error(
+        Bark.parse_message(unquote(env), unquote(opts)),
+        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
+      )
+    end
+  end
+
+  @deprecated "Use Bark.debug(opts) instead of Bark.debug(__ENV__, opts)"
+  defmacro debug(env, opts) do
+    quote do
+      require Logger
+      Logger.debug(
+        Bark.parse_message(unquote(env), unquote(opts)),
+        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
+      )
+    end
+  end
 
   @valid_colors [
     :black, :red, :green, :yellow, :blue, :magenta, :cyan, :white,
@@ -31,10 +123,10 @@ defmodule Bark do
     :light_cyan_background, :light_white_background
   ]
 
-  defp validate_ansi_color(color) when color in @valid_colors, do: color
-  defp validate_ansi_color(_), do: nil
+  def validate_ansi_color(color) when color in @valid_colors, do: color
+  def validate_ansi_color(_), do: nil
 
-  defp parse_message(env, opts) when is_list(opts) do
+  def parse_message(env, opts) when is_list(opts) do
     opts = Keyword.drop(opts, [:ansi_color])
 
     env

--- a/lib/bark.ex
+++ b/lib/bark.ex
@@ -9,6 +9,7 @@ defmodule Bark do
   defmacro warn(opts \\ []) do
     quote do
       require Logger
+
       Logger.warning(
         Bark.parse_message(__ENV__, unquote(opts)),
         ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
@@ -19,6 +20,7 @@ defmodule Bark do
   defmacro info(opts \\ []) do
     quote do
       require Logger
+
       Logger.info(
         Bark.parse_message(__ENV__, unquote(opts)),
         ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
@@ -29,6 +31,7 @@ defmodule Bark do
   defmacro audit(opts \\ []) do
     quote do
       require Logger
+
       Logger.notice(
         Bark.parse_message(__ENV__, unquote(opts)),
         ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
@@ -39,6 +42,7 @@ defmodule Bark do
   defmacro error(opts \\ []) do
     quote do
       require Logger
+
       Logger.error(
         Bark.parse_message(__ENV__, unquote(opts)),
         ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
@@ -49,6 +53,7 @@ defmodule Bark do
   defmacro debug(opts \\ []) do
     quote do
       require Logger
+
       Logger.debug(
         Bark.parse_message(__ENV__, unquote(opts)),
         ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
@@ -61,6 +66,7 @@ defmodule Bark do
   defmacro warn(env, opts) do
     quote do
       require Logger
+
       Logger.warning(
         Bark.parse_message(unquote(env), unquote(opts)),
         ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
@@ -72,6 +78,7 @@ defmodule Bark do
   defmacro info(env, opts) do
     quote do
       require Logger
+
       Logger.info(
         Bark.parse_message(unquote(env), unquote(opts)),
         ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
@@ -83,6 +90,7 @@ defmodule Bark do
   defmacro audit(env, opts) do
     quote do
       require Logger
+
       Logger.notice(
         Bark.parse_message(unquote(env), unquote(opts)),
         ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
@@ -94,6 +102,7 @@ defmodule Bark do
   defmacro error(env, opts) do
     quote do
       require Logger
+
       Logger.error(
         Bark.parse_message(unquote(env), unquote(opts)),
         ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
@@ -105,6 +114,7 @@ defmodule Bark do
   defmacro debug(env, opts) do
     quote do
       require Logger
+
       Logger.debug(
         Bark.parse_message(unquote(env), unquote(opts)),
         ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
@@ -113,14 +123,38 @@ defmodule Bark do
   end
 
   @valid_colors [
-    :black, :red, :green, :yellow, :blue, :magenta, :cyan, :white,
-    :light_black, :light_red, :light_green, :light_yellow, :light_blue,
-    :light_magenta, :light_cyan, :light_white,
-    :black_background, :red_background, :green_background, :yellow_background,
-    :blue_background, :magenta_background, :cyan_background, :white_background,
-    :light_black_background, :light_red_background, :light_green_background,
-    :light_yellow_background, :light_blue_background, :light_magenta_background,
-    :light_cyan_background, :light_white_background
+    :black,
+    :red,
+    :green,
+    :yellow,
+    :blue,
+    :magenta,
+    :cyan,
+    :white,
+    :light_black,
+    :light_red,
+    :light_green,
+    :light_yellow,
+    :light_blue,
+    :light_magenta,
+    :light_cyan,
+    :light_white,
+    :black_background,
+    :red_background,
+    :green_background,
+    :yellow_background,
+    :blue_background,
+    :magenta_background,
+    :cyan_background,
+    :white_background,
+    :light_black_background,
+    :light_red_background,
+    :light_green_background,
+    :light_yellow_background,
+    :light_blue_background,
+    :light_magenta_background,
+    :light_cyan_background,
+    :light_white_background
   ]
 
   def validate_ansi_color(color) when color in @valid_colors, do: color

--- a/lib/bark.ex
+++ b/lib/bark.ex
@@ -61,66 +61,29 @@ defmodule Bark do
     end
   end
 
-  # Deprecated old style macros (backward compatibility)
   @deprecated "Use Bark.warn(opts) instead of Bark.warn(__ENV__, opts)"
-  defmacro warn(env, opts) do
-    quote do
-      require Logger
-
-      Logger.warning(
-        Bark.parse_message(unquote(env), unquote(opts)),
-        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
-      )
-    end
-  end
+  @spec warn(Macro.Env.t(), Keyword.t()) :: :ok
+  def warn(env, opts),
+    do:
+      Logger.warning(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @deprecated "Use Bark.info(opts) instead of Bark.info(__ENV__, opts)"
-  defmacro info(env, opts) do
-    quote do
-      require Logger
-
-      Logger.info(
-        Bark.parse_message(unquote(env), unquote(opts)),
-        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
-      )
-    end
-  end
+  @spec info(Macro.Env.t(), Keyword.t()) :: :ok
+  def info(env, opts),
+    do: Logger.info(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @deprecated "Use Bark.audit(opts) instead of Bark.audit(__ENV__, opts)"
-  defmacro audit(env, opts) do
-    quote do
-      require Logger
-
-      Logger.notice(
-        Bark.parse_message(unquote(env), unquote(opts)),
-        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
-      )
-    end
-  end
+  def audit(env, opts),
+    do:
+      Logger.notice(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @deprecated "Use Bark.error(opts) instead of Bark.error(__ENV__, opts)"
-  defmacro error(env, opts) do
-    quote do
-      require Logger
-
-      Logger.error(
-        Bark.parse_message(unquote(env), unquote(opts)),
-        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
-      )
-    end
-  end
+  def error(env, opts),
+    do: Logger.error(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @deprecated "Use Bark.debug(opts) instead of Bark.debug(__ENV__, opts)"
-  defmacro debug(env, opts) do
-    quote do
-      require Logger
-
-      Logger.debug(
-        Bark.parse_message(unquote(env), unquote(opts)),
-        ansi_color: Bark.validate_ansi_color(unquote(opts)[:ansi_color])
-      )
-    end
-  end
+  def debug(env, opts),
+    do: Logger.debug(parse_message(env, opts), ansi_color: validate_ansi_color(opts[:ansi_color]))
 
   @valid_colors [
     :black,

--- a/test/bark_test.exs
+++ b/test/bark_test.exs
@@ -1,0 +1,103 @@
+defmodule BarkTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+  require Bark
+
+  describe "Bark" do
+    test "can log metadata of type: keyword list" do
+      opts = [key: "key", message: "oh no", user_id: 123, action: "login"]
+
+      log_output = capture_log(fn -> Bark.info(opts) end)
+
+      assert_log_output(log_output, :info, IO.ANSI.normal(), opts)
+    end
+
+    test "can log metadata of type: list of two-element tuples" do
+      opts = [{"key", "key"}, {"message", "oh no"}, {"user_id", 456}, {"action", "login"}]
+
+      log_output = capture_log(fn -> Bark.info(opts) end)
+
+      assert_log_output(log_output, :info, IO.ANSI.normal(), opts)
+    end
+
+    test "can log with opts[:ansi_color]" do
+      opts = [key: "key", message: "oh no", user_id: 123, action: "login"]
+
+      # Test with valid color
+      log_output = capture_log(fn -> Bark.info(opts ++ [ansi_color: :yellow]) end)
+
+      assert_log_output(log_output, :info, IO.ANSI.yellow(), opts)
+
+      # Test with invalid color - should not crash
+      log_output = capture_log(fn -> Bark.info(opts ++ [ansi_color: :invalid_color]) end)
+
+      assert_log_output(log_output, :info, IO.ANSI.normal(), opts)
+    end
+
+    test "debug logs at debug level" do
+      opts = [key: "key", message: "oh no", user_id: 123, action: "login"]
+
+      log_output = capture_log([level: :debug], fn -> Bark.debug(opts) end)
+
+      assert_log_output(log_output, :debug, IO.ANSI.cyan(), opts)
+    end
+
+    test "info logs at info level" do
+      opts = [key: "key", message: "oh no", user_id: 123, action: "login"]
+
+      log_output = capture_log([level: :info], fn -> Bark.info(opts) end)
+
+      assert_log_output(log_output, :info, IO.ANSI.normal(), opts)
+    end
+
+    test "audit logs at notice level" do
+      opts = [key: "key", message: "oh no", user_id: 123, action: "login"]
+
+      log_output = capture_log([level: :notice], fn -> Bark.audit(opts) end)
+
+      assert_log_output(log_output, :notice, IO.ANSI.normal(), opts)
+    end
+
+    test "warn logs at warning level" do
+      opts = [key: "key", message: "oh no", user_id: 123, action: "login"]
+
+      log_output = capture_log([level: :warning], fn -> Bark.warn(opts) end)
+
+      assert_log_output(log_output, :warning, IO.ANSI.yellow(), opts)
+    end
+
+    test "error" do
+      opts = [key: "key", message: "oh no", user_id: 123, action: "login"]
+
+      log_output = capture_log([level: :error], fn -> Bark.error(opts) end)
+
+      assert_log_output(log_output, :error, IO.ANSI.red(), opts)
+    end
+  end
+
+  defp assert_log_output(output, level_atom, ansi_color, opts) do
+    assert output =~ "[#{level_atom}]"
+    assert output =~ ansi_color
+
+    Enum.each(opts, fn pair ->
+      assert output =~ opt_pair_to_string(pair)
+    end)
+
+    assert output =~ IO.ANSI.reset()
+  end
+
+  defp opt_pair_to_string({key, value}) when is_binary(value) do
+    value =
+      case String.split(value, " ") do
+        [one] when is_binary(one) -> one
+        _ -> "\"#{value}\""
+      end
+
+    "#{key}=#{value}"
+  end
+
+  defp opt_pair_to_string({key, value}) do
+    "#{key}=#{value}"
+  end
+end


### PR DESCRIPTION
Aims to address https://github.com/smartrent/bark/issues/9

TODO: Tests
