### PR TITLE
ENG: Add actual log formatter

### DIFF
--- a/lib/log_formatter.ex
+++ b/lib/log_formatter.ex
@@ -1,9 +1,11 @@
 defmodule Bark.LogFormatter do
   @moduledoc """
-
   To use in an application, add this in `config/`
 
   ```elixir
+  config :logger, :console, format: "..."
+
+  # Pulls the format string from existing console logger, or uses a default
   config :logger, :default_formatter,
       format: {Bark.LogFormatter, :format},
   ```

--- a/lib/log_formatter.ex
+++ b/lib/log_formatter.ex
@@ -1,0 +1,70 @@
+defmodule Bark.LogFormatter do
+  @moduledoc """
+
+  To use in an application, add this in `config/`
+
+  ```elixir
+  config :logger, :default_formatter,
+      format: {Bark.LogFormatter, :format},
+  ```
+
+  https://hexdocs.pm/logger/1.17.3/Logger.Formatter.html#module-formatting-function
+  """
+
+  @default_format "$time $metadata[$level] $message\n"
+  @format :logger
+          |> Application.compile_env(:console, [])
+          |> Keyword.get(:format, @default_format)
+
+  @spec format(atom, IO.chardata(), Logger.Formatter.date_time_ms(), keyword()) :: IO.chardata()
+  def format(level, message, timestamp, metadata) do
+    metadata = metadata |> format_metadata() |> escape_values()
+
+    Logger.Formatter.format(
+      Logger.Formatter.compile(@format),
+      level,
+      message,
+      timestamp,
+      metadata
+    )
+  end
+
+  # In order to not break existing DataDog log queries for logs in DataDog,
+  # we have to match the same log/metadata format as defined in Bark.parse_message
+  # we manually
+  defp format_metadata(metadata) do
+    case Keyword.get(metadata, :mfa) do
+      {module, function, arity} ->
+        module = module |> Atom.to_string() |> String.replace("Elixir.", "")
+        command = "#{function}/#{arity}"
+
+        metadata
+        |> Keyword.put_new(:module, module)
+        |> Keyword.put_new(:command, command)
+
+      _ ->
+        metadata
+    end
+  end
+
+  defp escape_values(metadata) do
+    Enum.map(metadata, fn {key, value} ->
+      {maybe_escape(key), maybe_escape(value)}
+    end)
+  end
+
+  defp maybe_escape(value) when is_atom(value), do: Atom.to_string(value)
+  defp maybe_escape(value) when is_binary(value), do: escape_space_separated_string(value)
+  defp maybe_escape(value), do: value
+
+  # Quote string if it contains a space and there are quotes within in the string,
+  # replace them with something that doesn't break the DataDog parser.
+  defp escape_space_separated_string(value) when is_binary(value) do
+    if String.contains?(value, " ") do
+      value_without_escaped_quotes = String.replace(value, "\"", "″")
+      "\"#{value_without_escaped_quotes}\""
+    else
+      value
+    end
+  end
+end

--- a/test/log_formatter_test.exs
+++ b/test/log_formatter_test.exs
@@ -1,0 +1,56 @@
+defmodule Bark.LogFormatterTest do
+  use ExUnit.Case, async: true
+
+  describe "Bark.LogFormatter" do
+    test "format works" do
+      # https://hexdocs.pm/logger/1.17.3/Logger.html#module-metadata
+      metadata = [
+        mfa: {Bark.LogFormatter, :format, 4},
+        line: 42,
+        file: "lib/log_formatter.ex",
+        some_other_key: "it works with \"escaped\" strings as well"
+      ]
+
+      date = {2025, 8, 11}
+      time_ms = {14, 45, 0, 0}
+
+      logged_string =
+        IO.chardata_to_string(
+          Bark.LogFormatter.format(
+            :info,
+            "This is a test message",
+            {date, time_ms},
+            metadata
+          )
+        )
+
+      assert logged_string =~ "14:45:00.000"
+      assert logged_string =~ "module=Bark.LogFormatter"
+      assert logged_string =~ "command=format/4"
+      assert logged_string =~ "some_other_key=\"it works with ″escaped″ strings as well\""
+      assert logged_string =~ "[info]"
+      assert logged_string =~ "This is a test message\n"
+    end
+
+    test "format doesn't crash on missing metadata" do
+      metadata = []
+
+      date = {2025, 8, 11}
+      time_ms = {14, 45, 0, 0}
+
+      logged_string =
+        IO.chardata_to_string(
+          Bark.LogFormatter.format(
+            :info,
+            "This is a test message",
+            {date, time_ms},
+            metadata
+          )
+        )
+
+      assert logged_string =~ "14:45:00.000"
+      assert logged_string =~ "[info]"
+      assert logged_string =~ "This is a test message\n"
+    end
+  end
+end


### PR DESCRIPTION
Partially based on:
- This PR: https://github.com/smartrent/bark/pull/11
- This Slack thread: https://smartrentcom.slack.com/archives/C8WMLK4TY/p1754945754119099

## TODO:
- Test in CMW; verify that logs end up in DD as we expect.
- Verify formatting isn't broken compared to existing `Bark` usage.